### PR TITLE
Update README.md - Fix Vercel deploy link

### DIFF
--- a/evi-next-js-pages-router/README.md
+++ b/evi-next-js-pages-router/README.md
@@ -13,7 +13,7 @@ This project features a sample implementation of Hume's [Empathic Voice Interfac
 
 Click the button below to deploy this example project with Vercel:
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fhumeai%2Fhume-evi-next-js-starter&env=HUME_API_KEY,HUME_CLIENT_SECRET)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fhumeai%2Fhume-evi-next-js-pages-router&env=HUME_API_KEY,HUME_CLIENT_SECRET)
 
 Below are the steps to completing deployment:
 


### PR DESCRIPTION
The current deploy link points to the app router version