### PR TITLE
chore(flutter-example): add config id to api call

### DIFF
--- a/evi-flutter-example/lib/main.dart
+++ b/evi-flutter-example/lib/main.dart
@@ -279,6 +279,10 @@ class _MyHomePageState extends State<MyHomePage> {
       throw Exception('Please set your Hume API credentials in main.dart');
     }
 
+    if (ConfigManager.instance.humeConfigId.isNotEmpty) {
+      uri += "&config_id=${ConfigManager.instance.humeConfigId}";
+    }
+
     _chatChannel = WebSocketChannel.connect(Uri.parse(uri));
 
     _chatChannel!.stream.listen(


### PR DESCRIPTION
## Context
As I was using the initial code, I was confused as to why it wasn't picking up all the configurations that I setup in the dashboard such as voice, initial message, system prompt, etc.

## Solution
Append the `configId` as a query param to the api uri.