### PR TITLE
Flutter example: swift fixes

### DIFF
--- a/evi-flutter-example/.gitignore
+++ b/evi-flutter-example/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # Environment variables related

--- a/evi-flutter-example/audio/ios/Classes/SoundPlayer.swift
+++ b/evi-flutter-example/audio/ios/Classes/SoundPlayer.swift
@@ -39,7 +39,11 @@ public class SoundPlayer: NSObject, AVAudioPlayerDelegate {
             do {
                 try playNextInQueue()
             } catch {
-                self.onError?(error as! SoundPlayerError)
+                if let soundError = error as? SoundPlayerError {
+                    self.onError?(soundError)
+                } else {
+                    self.onError?(SoundPlayerError.decodeError(details: error.localizedDescription))
+                }
             }
         }
     }
@@ -59,8 +63,9 @@ public class SoundPlayer: NSObject, AVAudioPlayerDelegate {
         self.audioPlayer!.prepareToPlay()
         self.audioPlayer!.delegate = self
         let result = audioPlayer!.play()
-        
-        let isSpeaker = session.currentRoute.outputs.first?.portType == AVAudioSession.Port.builtInSpeaker
+
+        let isSpeaker =
+            session.currentRoute.outputs.first?.portType == AVAudioSession.Port.builtInSpeaker
         if isSpeaker {
             // This is to work around an issue with AVFoundation and voiceProcessing: https://forums.developer.apple.com/forums/thread/721535
             self.audioPlayer!.volume = 1.0

--- a/evi-flutter-example/audio/lib/audio.dart
+++ b/evi-flutter-example/audio/lib/audio.dart
@@ -25,7 +25,7 @@ class Audio {
               final audioData = event['data'] as String;
               _audioController.add(audioData);
             } else if (event['type'] == 'error') {
-              final error = event['data'] as String;
+              final error = event['message'] as String;
               _audioController.addError(error);
             }
           }


### PR DESCRIPTION
1. Fixes an unsafe cast for error messages in Swift.
2. Makes the dart side agree with the swift side about what the field name of error messages should be.