### PR TITLE
Update react-native example to produce audible output on device speaker.

### DIFF
--- a/evi-react-native-example/modules/audio/ios/SoundPlayer.swift
+++ b/evi-react-native-example/modules/audio/ios/SoundPlayer.swift
@@ -56,7 +56,8 @@ public class SoundPlayer: NSObject, AVAudioPlayerDelegate {
         self.audioPlayer = try AVAudioPlayer(data: data, fileTypeHint: AVFileType.wav.rawValue)
 
         self.audioPlayer!.delegate = self
-        self.audioPlayer!.volume = 1.0
+        // Produce audible output when playing over the device speaker.
+        self.audioPlayer!.volume = 50
         let result = audioPlayer!.play()
         if !result {
             throw SoundPlayerError.couldNotPlayAudio


### PR DESCRIPTION
As part of https://github.com/HumeAI/hume-api-examples/pull/148, I noticed the volume coming out of the speaker was super-low. After wrestling with the `AVAudioSession` configuration, I tried boosting the volume from `AVAudioPlayer`. Despite the docs stating the acceptable range is 0-1, setting this beyond 1 actually had the desired effect! I tested this in the simulator too, to ensure it doesn't blow out the volume when run on a laptop.