### PR TITLE
Update tts quickstarts

### DIFF
--- a/tts/tts-python-quickstart/app.py
+++ b/tts/tts-python-quickstart/app.py
@@ -146,15 +146,16 @@ async def main() -> None:
 
     # Streaming example with audio playback
     print("Streaming audio...")
+    voice = PostedUtteranceVoiceWithName(name=name)
     with get_audio_player() as player:
         async for snippet in hume.tts.synthesize_json_streaming(
             context=PostedContextWithGenerationId(
                 generation_id=speech3.generations[0].generation_id,
             ),
             utterances=[
-                PostedUtterance(text="He's drawn the bow..."),
-                PostedUtterance(text="he's fired the arrow..."),
-                PostedUtterance(text="I can't believe it! A perfect bullseye!")
+                PostedUtterance(text="He's drawn the bow...", voice=voice),
+                PostedUtterance(text="he's fired the arrow...", voice=voice),
+                PostedUtterance(text="I can't believe it! A perfect bullseye!", voice=voice)
             ],
             # Uncomment to reduce latency to < 500ms, at a 10% higher cost
             # instant_mode=True,

--- a/tts/tts-typescript-quickstart/index.ts
+++ b/tts/tts-typescript-quickstart/index.ts
@@ -75,6 +75,7 @@ const main = async () => {
   await writeResultToFile(speech2.generations[0].audio, "speech2_0")
   await writeResultToFile(speech2.generations[1].audio, "speech2_1")
 
+  const voice = { name }
   const speech3 = await hume.tts.synthesizeJson({
     utterances: [{
       voice: { name },
@@ -93,14 +94,9 @@ const main = async () => {
     context: {
       generationId: speech3.generations[0].generationId,
     },
-    utterances: [{ text: "He's drawn the bow..." }, { text: "he's fired the arrow..." }, { text: "I can't believe it! A perfect bullseye!" }],
-    // Uncomment to reduce latency to < 500ms, at a 10% higher cost
-    // instantMode: true,
-    //
-    // By default, the audio data of every chunk returned by `synthesizeJsonStreaming` is a standalone 'mp3' file.
-    // The `playAudio` function expects to receive a single audio file. You can pass the `stripHeaders` option to
-    // remove the "headers" from each chunk so that the streamed audio can be played as a single file.
-    // TODO: stripHeaders: true
+    utterances: [{ voice, text: "He's drawn the bow..." }, { voice, text: "he's fired the arrow..." }, { voice, text: "I can't believe it! A perfect bullseye!" }],
+
+    stripHeaders: true
   })) {
     audioPlayer.sendAudio(snippet.audio)
   }


### PR DESCRIPTION
Streaming uses instant_mode by default now, so we should specify `voice` in the utterances.